### PR TITLE
11-modify-logic-to-allow-any-payer-from-the-expense-group feature added

### DIFF
--- a/src/main/java/com/satwik/splitwiseclone/persistence/dto/expense/ExpenseDTO.java
+++ b/src/main/java/com/satwik/splitwiseclone/persistence/dto/expense/ExpenseDTO.java
@@ -16,6 +16,8 @@ public class ExpenseDTO {
 
     private String payerName;
 
+    private UUID payerId;
+
     @NotNull
     private double amount;
 

--- a/src/main/java/com/satwik/splitwiseclone/persistence/dto/user/OwerDTO.java
+++ b/src/main/java/com/satwik/splitwiseclone/persistence/dto/user/OwerDTO.java
@@ -4,10 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class OwerDTO {
+
+    UUID userId;
 
     String username;
 

--- a/src/main/java/com/satwik/splitwiseclone/persistence/entities/ExpenseShare.java
+++ b/src/main/java/com/satwik/splitwiseclone/persistence/entities/ExpenseShare.java
@@ -8,7 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "expense_share")
+@Table(name = "expense_share", uniqueConstraints = { @UniqueConstraint(columnNames = { "expense_id", "user_id" }) })
 public class ExpenseShare extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/satwik/splitwiseclone/persistence/entities/GroupMembers.java
+++ b/src/main/java/com/satwik/splitwiseclone/persistence/entities/GroupMembers.java
@@ -8,7 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "group_members")
+@Table(name = "group_members")  // add unique constraint to avoid multiple entries of same user in same group
 public class GroupMembers extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/satwik/splitwiseclone/repository/ExpenseShareRepository.java
+++ b/src/main/java/com/satwik/splitwiseclone/repository/ExpenseShareRepository.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Repository
 public interface ExpenseShareRepository extends JpaRepository<ExpenseShare, UUID> {
 
-    @Query("SELECT NEW com.satwik.splitwiseclone.persistence.dto.user.OwerDTO(u.username, es.sharedAmount) " +
+    @Query("SELECT NEW com.satwik.splitwiseclone.persistence.dto.user.OwerDTO(u.id, u.username, es.sharedAmount) " +
             "FROM ExpenseShare es " +
             "INNER JOIN es.user u " +
             "WHERE es.expense.id = ?1")
@@ -37,4 +37,7 @@ public interface ExpenseShareRepository extends JpaRepository<ExpenseShare, UUID
     @Query("DELETE FROM ExpenseShare es " +
             "WHERE es.expense.id = ?1 AND es.user.id = ?2")
     void deleteByExpenseIdAndUserId(UUID expenseId, UUID owerId);
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM ExpenseShare es WHERE es.expense.id = ?1 AND es.user.id = ?2")
+    boolean existsByExpenseIdAndUserId(UUID expenseId, UUID owerId);
 }

--- a/src/main/java/com/satwik/splitwiseclone/repository/GroupMembersRepository.java
+++ b/src/main/java/com/satwik/splitwiseclone/repository/GroupMembersRepository.java
@@ -2,6 +2,7 @@ package com.satwik.splitwiseclone.repository;
 
 import com.satwik.splitwiseclone.persistence.entities.GroupMembers;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
@@ -9,5 +10,8 @@ import java.util.UUID;
 public interface GroupMembersRepository extends JpaRepository<GroupMembers, UUID> {
 
     List<GroupMembers> findByGroupId(UUID id);
+
+    @Query(value = "SELECT COUNT(*) > 0 AS flag FROM GroupMembers g WHERE g.group.id = ?1 AND g.member.id = ?2")
+    boolean existsByGroupIdAndMemberId(UUID groupId, UUID memberId);
 
 }

--- a/src/main/java/com/satwik/splitwiseclone/service/implementations/GroupServiceImpl.java
+++ b/src/main/java/com/satwik/splitwiseclone/service/implementations/GroupServiceImpl.java
@@ -72,6 +72,7 @@ public class GroupServiceImpl implements GroupService {
     public String addGroupMembers(UUID groupId, UUID memberId) {
         Group group = groupRepository.findById(groupId).orElseThrow(() -> new DataNotFoundException("Group not found!"));
         User member = userRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException("User not found to add as member!"));
+        // TODO : add check to avoid add members to default group
         GroupMembers groupMembers = new GroupMembers();
         groupMembers.setMember(member);
         groupMembers.setGroup(group);


### PR DESCRIPTION
The following changes are covered in this PR:
1. Added a now value to return in ExpenseDTO (request/response body)
2. Added a unique constraint to avoid ower to be added multiple times in a single expense.
3. Added owerId in OwerDTO.
4. Added a check only to allow adding a user as a payer if they belong to the same group.
5. Added functionality to add any user as a payer to the expense.
6. Corrected the logic to calculate the shared amount among the owers and a payer in an expense.